### PR TITLE
Add app_name to profile

### DIFF
--- a/jobapp/apps/accountapp/urls.py
+++ b/jobapp/apps/accountapp/urls.py
@@ -1,7 +1,8 @@
-
 from django.contrib import admin
 from django.urls import path
 from . import views
+
+app_name = "accountapp"
 
 urlpatterns = [
     path("register/", views.Register, name="register"),


### PR DESCRIPTION
Based from https://docs.djangoproject.com/en/4.2/intro/tutorial03/#namespacing-url-names

app_name is placed at the start of  `apps/accountapp/urls.py` after the imports in order to be referenced on other apps. 