### PR TITLE
Update Tailwind and Use Daisy UI

### DIFF
--- a/jobapp/theme/static_src/package-lock.json
+++ b/jobapp/theme/static_src/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.9",
         "cross-env": "^7.0.3",
+        "daisyui": "^4.4.7",
         "postcss": "^8.4.24",
         "postcss-import": "^15.1.0",
         "postcss-nested": "^6.0.1",
@@ -387,6 +388,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-selector-tokenizer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
+      "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "fastparse": "^1.1.2"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -397,6 +408,34 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/culori": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/culori/-/culori-3.3.0.tgz",
+      "integrity": "sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-4.4.7.tgz",
+      "integrity": "sha512-E+jAcaCiXmBgLePaGjH2aEoyp5kthkEO7S0db8JoWNxZ/4q5x6sgdR/+mCphKVXMJMOihGIL0Y8psqFIMxCdBg==",
+      "dev": true,
+      "dependencies": {
+        "css-selector-tokenizer": "^0.8",
+        "culori": "^3",
+        "picocolors": "^1",
+        "postcss-js": "^4"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/daisyui"
       }
     },
     "node_modules/didyoumean": {
@@ -450,6 +489,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.15.0",

--- a/jobapp/theme/static_src/package.json
+++ b/jobapp/theme/static_src/package.json
@@ -19,6 +19,7 @@
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.9",
     "cross-env": "^7.0.3",
+    "daisyui": "^4.4.7",
     "postcss": "^8.4.24",
     "postcss-import": "^15.1.0",
     "postcss-nested": "^6.0.1",

--- a/jobapp/theme/static_src/src/styles.css
+++ b/jobapp/theme/static_src/src/styles.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
+
+@layer base {
+  html {
+    font-family: "Noto Sans", system-ui, sans-serif;
+  }
+}

--- a/jobapp/theme/static_src/src/styles.css
+++ b/jobapp/theme/static_src/src/styles.css
@@ -1,9 +1,12 @@
+/* Imports the font, but internet says its not best practice since it defer the loading of the included resource until the file is fetched. Commented for now. Best to use <link/> for fonts instead */
+/* https://stackoverflow.com/questions/12316501/including-google-fonts-link-or-import/12380004#12380004 */
+/* @import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"); */
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
-
+/* Overrides the default base configuration */
 @layer base {
   html {
     font-family: "Noto Sans", system-ui, sans-serif;

--- a/jobapp/theme/static_src/tailwind.config.js
+++ b/jobapp/theme/static_src/tailwind.config.js
@@ -6,53 +6,85 @@
  */
 
 module.exports = {
-    content: [
-        /**
-         * HTML. Paths to Django template files that will contain Tailwind CSS classes.
-         */
+  content: [
+    /**
+     * HTML. Paths to Django template files that will contain Tailwind CSS classes.
+     */
 
-        /*  Templates within theme app (<tailwind_app_name>/templates), e.g. base.html. */
-        '../templates/**/*.html',
+    /*  Templates within theme app (<tailwind_app_name>/templates), e.g. base.html. */
+    "../templates/**/*.html",
 
-        /*
-         * Main templates directory of the project (BASE_DIR/templates).
-         * Adjust the following line to match your project structure.
-         */
-        '../../templates/**/*.html',
+    /*
+     * Main templates directory of the project (BASE_DIR/templates).
+     * Adjust the following line to match your project structure.
+     */
+    "../../templates/**/*.html",
 
-        /*
-         * Templates in other django apps (BASE_DIR/<any_app_name>/templates).
-         * Adjust the following line to match your project structure.
-         */
-        '../../**/templates/**/*.html',
+    /*
+     * Templates in other django apps (BASE_DIR/<any_app_name>/templates).
+     * Adjust the following line to match your project structure.
+     */
+    "../../**/templates/**/*.html",
 
-        /**
-         * JS: If you use Tailwind CSS in JavaScript, uncomment the following lines and make sure
-         * patterns match your project structure.
-         */
-        /* JS 1: Ignore any JavaScript in node_modules folder. */
-        // '!../../**/node_modules',
-        /* JS 2: Process all JavaScript files in the project. */
-        // '../../**/*.js',
+    /**
+     * JS: If you use Tailwind CSS in JavaScript, uncomment the following lines and make sure
+     * patterns match your project structure.
+     */
+    /* JS 1: Ignore any JavaScript in node_modules folder. */
+    // '!../../**/node_modules',
+    /* JS 2: Process all JavaScript files in the project. */
+    // '../../**/*.js',
 
-        /**
-         * Python: If you use Tailwind CSS classes in Python, uncomment the following line
-         * and make sure the pattern below matches your project structure.
-         */
-        // '../../**/*.py'
-    ],
-    theme: {
-        extend: {},
+    /**
+     * Python: If you use Tailwind CSS classes in Python, uncomment the following line
+     * and make sure the pattern below matches your project structure.
+     */
+    // '../../**/*.py'
+  ],
+  theme: {
+    extend: {
+      // custom font family. Must include the link of the fonts first in the <head> to utilize it. just include it here like this: "lato": ['Lato', 'sans-serif']
+      // empty for now.
     },
-    plugins: [
-        /**
-         * '@tailwindcss/forms' is the forms plugin that provides a minimal styling
-         * for forms. If you don't like it or have own styling for forms,
-         * comment the line below to disable '@tailwindcss/forms'.
-         */
-        require('@tailwindcss/forms'),
-        require('@tailwindcss/typography'),
-        require('@tailwindcss/line-clamp'),
-        require('@tailwindcss/aspect-ratio'),
-    ],
-}
+  },
+  plugins: [
+    /**
+     * '@tailwindcss/forms' is the forms plugin that provides a minimal styling
+     * for forms. If you don't like it or have own styling for forms,
+     * comment the line below to disable '@tailwindcss/forms'.
+     */
+    require("@tailwindcss/forms"),
+    require("@tailwindcss/typography"),
+    require("@tailwindcss/line-clamp"),
+    require("@tailwindcss/aspect-ratio"),
+    // Plugin for daisy-ui
+    require("daisyui"),
+  ],
+  // daisyUI config (optional - here are the default values)
+  daisyui: {
+    themes: [
+      {
+        default: {
+          primary: "#a7c957",
+          secondary: "#386641",
+          accent: "#bc4749",
+          neutral: "#ffffff",
+          "base-100": "#ffffff",
+          info: "#ffffff",
+          success: "#a7c957",
+          warning: "#eab308",
+          error: "#be123c",
+          light: "#f2e8cf",
+        },
+      },
+    ], // false: only light + dark | true: all themes | array: specific themes like this ["light", "dark", "cupcake"]
+    darkTheme: "dark", // name of one of the included themes for dark mode
+    base: false, // applies background color and foreground color for root element by default
+    styled: false, // include daisyUI colors and design decisions for all components
+    utils: true, // adds responsive and modifier utility classes
+    // use this in order to call daisyUI components. instead of btn, calll the class daisy-btn
+    prefix: "daisy-", // prefix for daisyUI classnames (components, modifiers and responsive class names. Not colors)
+    logs: true, // Shows info about daisyUI version and used config in the console when building your CSS
+    themeRoot: ":root", // The element that receives theme color CSS variables
+  },
+};


### PR DESCRIPTION
- Added Daisy UI plugin for tailwind.
- Added Noto Sans as the base font.

To use Daisy UI and ensure Tailwind works:
- navigate to the directory where `package.json` live
- type `npm install` on the command line
- run `npm start` to check 

Use this to include Noto to your templates
```html
    <link
      href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
      rel="stylesheet"
    />
 ```
 For css import vs html link element reference: https://stackoverflow.com/questions/12316501/including-google-fonts-link-or-import/12380004#12380004